### PR TITLE
Add about large print

### DIFF
--- a/04_venue_selection.md
+++ b/04_venue_selection.md
@@ -24,7 +24,9 @@ title: Venue Selection &amp; On-Site Services
 
 - ✅ Book sign-language interpreters and/or real-time captioning (someone typing captions) for deaf and hard-of-hearing attendees. 
 - Consider using patterns rather than just color on signs and presentation slides to indicate differences, to make comprehension easier for attendees with color blindness/low vision issues.
-- 🍎 Provide large-text signs and easy-to-read maps. Ask conference organizers to announce important information over the microphone, which helps people with impaired vision.
+- Provide large-text signs and easy-to-read maps.
+- Provide large-print copies of printed materials, such as program booklets, via printing normally A5 documents on A4, or folded A4-booklets on A3.
+- 🍎 Ask conference organizers to announce important information over the microphone, which helps people with impaired vision.
 - Include maps in advance, with the event schedule. 
 - Make sure that hand-held microphones are available 
 - Encourage session chairs to repeat questions from the audience over the mic so everyone can hear


### PR DESCRIPTION
This is one that effects me. If there is a document I will have to read often. (e.g. a timetable)
Then my life is much enhanced if it is 2x the normal size.
And it is pretty easy, have been doing it a while and maybe 3% of people ask for one.
Especially older people.

This change perhaps should be in the 11_inclusive_practices_during_checkin.md
document, since it is mostly documents given out at check in that are worth having in large print.
However, most of the other disability stuff is in venue including other things like having things announced over microphone.
So i put it there. Reorganisation of the document is worth thinking about.