### PR TITLE
80: Fixed Preview Github Action Runner

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Fixed Preview Github Action Runner

- This pull request addresses the preview fix by adding the write permission to the permissions.contents in a workflow/job.