### PR TITLE
Fixed incorrect link in DISCOVER/06_childcare.md (Closes #211)

### DIFF
--- a/DISCOVER/06_childcare.md
+++ b/DISCOVER/06_childcare.md
@@ -24,7 +24,7 @@
  
 - There are companies that provide childcare at conferences. While NumFOCUS makes no specific endorsements, we did find these companies in our research who are providing event-based childcare:
    - [Corporate Kids Events](https://conferencechildcare.com/)
-   - [American Child Care, Inc.](http://www.americanchildcare.com/conventions.htm)
+   - [American Child Care, Inc.](https://www.americanchildinc.org/)
    - [Kiddie Corp](http://www.kiddiecorp.com/)
    - [UrbanSitter](https://www.urbansitter.com/) provides a platform for finding babysitters. (*This link is only accessible within the United States*)
    - [Care.com](https://www.care.com/)

--- a/DISCOVER/06_childcare.md
+++ b/DISCOVER/06_childcare.md
@@ -24,7 +24,6 @@
  
 - There are companies that provide childcare at conferences. While NumFOCUS makes no specific endorsements, we did find these companies in our research who are providing event-based childcare:
    - [Corporate Kids Events](https://conferencechildcare.com/)
-   - [American Child Care, Inc.](https://www.americanchildinc.org/)
    - [Kiddie Corp](http://www.kiddiecorp.com/)
    - [UrbanSitter](https://www.urbansitter.com/) provides a platform for finding babysitters. (*This link is only accessible within the United States*)
    - [Care.com](https://www.care.com/)


### PR DESCRIPTION
I saw the problem with the link provided here. I checked out their official Facebook page; it shared the same link and redirected to an unsafe website. There are many sites with American Childcare Inc., so it took some time to find the official site. I was able to find their official site and resolve the issue in the file. 

