### PR TITLE
43 : add link to interactive fiction example for organizers

### DIFF
--- a/DISCOVER/03_organizing_committee.md
+++ b/DISCOVER/03_organizing_committee.md
@@ -26,4 +26,6 @@ When creating the organizing committee, be aware of the specific roles assigned 
 
 - [Inclusive Approaches to Recruitment & Outreach](https://www.numfocus.org/blog/inclusive-approaches-to-recruitment-outreach-notes-from-the-disc-unconference/)
 - [CRA-W Best Practices: Guidelines in Running an Inclusive Conference](https://cra.org/cra-w/wp-content/uploads/sites/5/2018/05/CRAW-Best-Practices-for-Conferences-v5.pdf)
+- [Link to interactive fiction example](https://github.com/softwaresaved/eventure)
+
 


### PR DESCRIPTION
This PR adds a link to the interactive fiction example for organizers (https://github.com/softwaresaved/eventure) under the "Further Reading" section in the Organizing Committee document. This resource can help organizers explore inclusive and effective event planning strategies through an interactive format.

Changes:
Added the link to the interactive fiction example for organizers.

Reasoning:
Including this link provides organizers with an engaging and practical resource to better understand diversity, bias mitigation, and inclusivity in event planning.

Closes #43 