### PR TITLE
Add Interactive Fiction Example Link to Further Reading Section

### DIFF
--- a/DISCOVER/01_about.md
+++ b/DISCOVER/01_about.md
@@ -1,7 +1,9 @@
 (about)=
+
 # About
 
 ## Summary
+
 This cookbook is intended as a resource for organizers of conferences and events with a particular focus on the tech sector in the United States. It focuses specifically on plans, decisions, and actions organizers can take to produce and manage a more diverse and inclusive event. The cookbook does not provide any specific advice about budgeting, scheduling, A/V capabilities, how to structure tracks, etc.
 
 ## About this Cookbook:
@@ -20,17 +22,15 @@ Some &quot;basic&quot; best practice is understood to be a prerequisite for many
 
 This cookbook also does not offer reasons or rationale for **why inclusion and diversity are important**. The cookbook presumes the organizing committee is already interested in improving diversity and inclusion at their conference or event. Hence the suggestions herein are focused on the &quot;how&quot; rather than the &quot;why&quot;.
 
-
 ## Acknowledgements:
 
 We sincerely appreciate the efforts and input of the many individuals who contributed to the creation of this cookbook. We also thank the numerous individuals and organizations whose work we have drawn from in order to compile this cookbook. Resources we consulted are collected at the end of each section under the heading &quot;Further Reading&quot;.
 
-- In particular, we thank: 
+- In particular, we thank:
 
   - The NumFOCUS DISC Committee members who compiled the initial skeleton of this cookbook: Jennifer Klay, Reshama Shaikh, and Gina Helfrich. And those who set up this page: Mwai Karimi, Bojan Božić and Leonie Mueck
 
   - Participants in the 2017 DISC Unconference who expanded and elaborated upon the initial skeleton: Kasia Rachuta, Ashley Otero, Dave Clements, Sarah Supp, Raniere Silva, and Tania Allard.
-
 
 ## Other Considerations
 
@@ -38,12 +38,12 @@ We sincerely appreciate the efforts and input of the many individuals who contri
 
 - [Scent and smoking policy](https://adacamp.org/adacamp-toolkit/policies/#scent)
 - [Conference booklet template](http://geekfeminism.wikia.com/wiki/Conference_booklet_template)
-
+- [Interactive Fiction Example for Conference Organizers](https://github.com/softwaresaved/eventure) - An interactive story that helps organizers understand potential scenarios they may encounter
 
 ## Special Considerations Depending on Geographic Context
 
-- Most of the material contained herein is written from the U.S. perspective (e.g. Americans with Disabilities Act (ADA) protections). 
-- Something to be aware of: some U.S. states may have discriminatory laws in place which could affect whether you should choose to host an event or conference there. 
+- Most of the material contained herein is written from the U.S. perspective (e.g. Americans with Disabilities Act (ADA) protections).
+- Something to be aware of: some U.S. states may have discriminatory laws in place which could affect whether you should choose to host an event or conference there.
 - We welcome input on considerations for events and conferences in other countries.
 - Additional considerations may need to be made for very remote event locations with no public transit, e.g. for folks who are mobility impaired.
 


### PR DESCRIPTION
## Description##
This PR adds a link to an interactive fiction example in the Further Reading section of the About page. This addresses issue #43 by providing conference organizers with an additional resource to help understand potential scenarios they may encounter when organizing inclusive events.

##ScreenShot##
![Screenshot 2025-03-20 005643](https://github.com/user-attachments/assets/cde25cea-e251-47a8-bba8-466f99c4e34f)


## Changes
- Added link to interactive fiction example under "Further Reading" in `01_about.md`
- The example helps organizers understand potential diversity and inclusion scenarios through an interactive story format

## Location of Change
The link was added to the "Further Reading" section in the About page since this is an introductory resource that organizers would encounter early in their journey through the cookbook.

## Related Issue
Closes #43 
Fixes #43 
