### PR TITLE
adding a dummy change

### DIFF
--- a/DISCOVER/01_about.md
+++ b/DISCOVER/01_about.md
@@ -38,6 +38,7 @@ We sincerely appreciate the efforts and input of the many individuals who contri
 
 - [Scent and smoking policy](https://adacamp.org/adacamp-toolkit/policies/#scent)
 - [Conference booklet template](http://geekfeminism.wikia.com/wiki/Conference_booklet_template)
+- [Twine](https://twinery.org/)-A tool for creating branching narratives. It’s great for interactive storytelling and decision-making.  
 
 
 ## Special Considerations Depending on Geographic Context


### PR DESCRIPTION
Description
This PR adds a link to Twine, an interactive fiction tool, in the Further Reading section of the About page. This addresses issue #43 by providing conference organizers with a resource that helps them understand potential scenarios they may encounter when organizing inclusive events.

Changes Made
✅ Added Twine link under "Further Reading" in 01_about.md

Why Twine?
Twine allows organizers to create branching narratives that simulate real-world decision-making.
It helps visualize diversity and inclusion scenarios in an engaging, interactive format.
Location of Change
📍 The link was added to the "Further Reading" section on the About page, ensuring organizers encounter it early in their learning journey.

Related Issue
 Closes #43
