### PR TITLE
Remove redundant data storage text from CoC Enforcement section

### DIFF
--- a/DISCOVER/01_about.md
+++ b/DISCOVER/01_about.md
@@ -1,7 +1,9 @@
 (about)=
+
 # About
 
 ## Summary
+
 This cookbook is intended as a resource for organizers of conferences and events with a particular focus on the tech sector in the United States. It focuses specifically on plans, decisions, and actions organizers can take to produce and manage a more diverse and inclusive event. The cookbook does not provide any specific advice about budgeting, scheduling, A/V capabilities, how to structure tracks, etc.
 
 ## About this Cookbook:
@@ -20,17 +22,15 @@ Some &quot;basic&quot; best practice is understood to be a prerequisite for many
 
 This cookbook also does not offer reasons or rationale for **why inclusion and diversity are important**. The cookbook presumes the organizing committee is already interested in improving diversity and inclusion at their conference or event. Hence the suggestions herein are focused on the &quot;how&quot; rather than the &quot;why&quot;.
 
-
 ## Acknowledgements:
 
 We sincerely appreciate the efforts and input of the many individuals who contributed to the creation of this cookbook. We also thank the numerous individuals and organizations whose work we have drawn from in order to compile this cookbook. Resources we consulted are collected at the end of each section under the heading &quot;Further Reading&quot;.
 
-- In particular, we thank: 
+- In particular, we thank:
 
   - The NumFOCUS DISC Committee members who compiled the initial skeleton of this cookbook: Jennifer Klay, Reshama Shaikh, and Gina Helfrich. And those who set up this page: Mwai Karimi, Bojan Božić and Leonie Mueck
 
   - Participants in the 2017 DISC Unconference who expanded and elaborated upon the initial skeleton: Kasia Rachuta, Ashley Otero, Dave Clements, Sarah Supp, Raniere Silva, and Tania Allard.
-
 
 ## Other Considerations
 
@@ -38,12 +38,12 @@ We sincerely appreciate the efforts and input of the many individuals who contri
 
 - [Scent and smoking policy](https://adacamp.org/adacamp-toolkit/policies/#scent)
 - [Conference booklet template](http://geekfeminism.wikia.com/wiki/Conference_booklet_template)
-
+- [Interactive Fiction Example for Conference Organizers](https://github.com/softwaresaved/eventure) - An interactive story that helps organizers understand potential scenarios they may encounter
 
 ## Special Considerations Depending on Geographic Context
 
-- Most of the material contained herein is written from the U.S. perspective (e.g. Americans with Disabilities Act (ADA) protections). 
-- Something to be aware of: some U.S. states may have discriminatory laws in place which could affect whether you should choose to host an event or conference there. 
+- Most of the material contained herein is written from the U.S. perspective (e.g. Americans with Disabilities Act (ADA) protections).
+- Something to be aware of: some U.S. states may have discriminatory laws in place which could affect whether you should choose to host an event or conference there.
 - We welcome input on considerations for events and conferences in other countries.
 - Additional considerations may need to be made for very remote event locations with no public transit, e.g. for folks who are mobility impaired.
 

--- a/DISCOVER/07_code_of_conduct.md
+++ b/DISCOVER/07_code_of_conduct.md
@@ -1,22 +1,26 @@
 ```{tags} Code-of-Conduct, Being-Respectful, Sexual-Harassment, Bullying, Giving-Participants-Room-To-Be-Who-They-Are
+
 ```
 
 (code_of_conduct)=
+
 # Code of Conduct (CoC)
 
- - 🍎 Articulate a Code of Conduct for your event
-  - Get inspired by Codes of Conduct that have been phrased for other conferences (see also "Further Reading")
- 
+- 🍎 Articulate a Code of Conduct for your event
+- Get inspired by Codes of Conduct that have been phrased for other conferences (see also "Further Reading")
+
 ## Goals
 
 **A Code of Conduct should:**
+
 - Be easy to read (You shouldn't need a law degree to understand it.)
 - Be easy to find
-- Explain how to report problematic or unethical behavior	
+- Explain how to report problematic or unethical behavior
 - Explain the consequences of violating Code of Conduct provisions
 - Include timelines/deadlines for enforcement action that will be taken
 
 Additional ways to support and implement your Code of Conduct:
+
 - Include FAQs
 - Encourage positive behavior (don't just discourage negative behavior)
 - Have a "quick" version and a "less quick" version (e.g. [JSConf](http://jsconf.com/codeofconduct.html))
@@ -25,21 +29,21 @@ Additional ways to support and implement your Code of Conduct:
 
 Make sure that **everyone involved in your conference/event** is aware that the Code of Conduct applies to them: that not only includes participants, but also speakers, sponsors, committee members etc.
 
- - 🍎 Tick box at registration that confirms that the participant has read the Code of Conduct
-     - A pop-up with a short version may also be a good idea.
-     - Provide a link to the full ("less quick") version of the Code of Conduct, hosted on its own page.
- - 🍎 Include a copy of the Code of Conduct in the sponsor packet
- - 🍎 Mention that the Code of Conduct applies to the speakers in the speaker guidelines
- - 🍎 Ensure that Code of Conduct is **easily** accessible on the conference website
-   - Should be in main navigation or in the footer (footer is a known pattern, near privacy policy / terms of service)
-   - Implement additional web-based highlights of the CoC via loading pages, pop-ups, screen savers, etc.
- - 🍎 Include a short version of the Code of Conduct on the printed schedule as a reminder
- - 🍎 Mention the Code of Conduct in the welcome talk and at the start of every day, including who to contact if there is a problem/violation
- - 🍎 Place Code of Conduct reminders on tables at lunch and also signs in rooms reminding people during the day
- - 🍎 Create a large banner sign at key entrances on the Code of Conduct as a reminder.
- - If you send out daily event e-mails, include an item on &quot;Seeing or experiencing something that makes you uncomfortable&quot;
-  - &quot;Remember that you can always speak to one of our ombudspersons about any matter of concern, no matter how small.&quot;
-- Include short blurbs about the Code of Conduct during breaks (e.g. during slide breaks), on websites, etc. 
+- 🍎 Tick box at registration that confirms that the participant has read the Code of Conduct
+  - A pop-up with a short version may also be a good idea.
+  - Provide a link to the full ("less quick") version of the Code of Conduct, hosted on its own page.
+- 🍎 Include a copy of the Code of Conduct in the sponsor packet
+- 🍎 Mention that the Code of Conduct applies to the speakers in the speaker guidelines
+- 🍎 Ensure that Code of Conduct is **easily** accessible on the conference website
+  - Should be in main navigation or in the footer (footer is a known pattern, near privacy policy / terms of service)
+  - Implement additional web-based highlights of the CoC via loading pages, pop-ups, screen savers, etc.
+- 🍎 Include a short version of the Code of Conduct on the printed schedule as a reminder
+- 🍎 Mention the Code of Conduct in the welcome talk and at the start of every day, including who to contact if there is a problem/violation
+- 🍎 Place Code of Conduct reminders on tables at lunch and also signs in rooms reminding people during the day
+- 🍎 Create a large banner sign at key entrances on the Code of Conduct as a reminder.
+- If you send out daily event e-mails, include an item on &quot;Seeing or experiencing something that makes you uncomfortable&quot;
+- &quot;Remember that you can always speak to one of our ombudspersons about any matter of concern, no matter how small.&quot;
+- Include short blurbs about the Code of Conduct during breaks (e.g. during slide breaks), on websites, etc.
 - Consider a visual &quot;workflow&quot; of Code of Conduct violation:
   - Report -&gt; Action -&gt; Resolution
 - Make it clear what the consequences or resolutions of a violation are
@@ -54,25 +58,24 @@ Make sure that **everyone involved in your conference/event** is aware that the 
   - Fill out an online form, e.g. [O'Reilly Report CoC](http://www.oreilly.com/conferences/report-code-of-conduct.html)
 - Consider how a report against an authority figure would be submitted — e.g. if the ombudsperson is the subject of a CoC violation report, who is the report submitted to? (A good reason to have more than one ombudsperson.)
 
-
 ## Enforcement
 
 - Be clear on how long it will take to resolve the situation or take an action on the violation
 - Discuss in advance with the organizing committee what the specific process will be for recording and addressing a CoC violation
-- When recording a CoC violation, ensure that the data are stored securely and that everyone&#39;s identities are protected. Access to the data should be limited.
 - When possible, have a third party review the violation report (Another good way to handle the challenge of potential reports against authority figures.)
 - Ensure the person who made the CoC violation report is aware of how it is being handled and when it has been resolved.
-
 
 ## Further reading
 
 **Why You Need a Code of Conduct**
+
 - [Why to have a CoC and how to make one](http://incisive.nu/2014/codes-of-conduct/)
 - [Why conferences need a code of conduct](https://jacobian.org/writing/codes-of-conduct/)
 - [Human Decency Is Not Enough: Why Cons Need Better Anti-Harassment Policies](https://www.wired.com/2013/07/convention-harassment-comic-con/)
 - [Should my tech conference community have a code of conduct and recommended resources](http://wunder.schoenaberselten.com/2016/02/17/should-my-tech-conference-community-have-a-code-of-conduct-recommended-resources/)
 
 **Crafting a Code of Conduct**
+
 - [A CoC builder](http://codeofconduct.io)
 - [Conference Code of Conduct](http://confcodeofconduct.com/)
 - [Codes of Conduct 101 + FAQ](https://www.ashedryden.com/blog/codes-of-conduct-101-faq)
@@ -80,6 +83,6 @@ Make sure that **everyone involved in your conference/event** is aware that the 
 - [How Tech Codes of Conduct Fail](https://medium.com/@gusseting/tech-codes-of-conduct-e4e05c6f539f)
 
 **Managing a Code of Conduct**
+
 - [NYC PyLadies Meetup: Managing our Code of Conduct](https://reshamas.github.io/managing-our-code-of-conduct/)
 - [Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)
-

--- a/DISCOVER/09_participant_selection.md
+++ b/DISCOVER/09_participant_selection.md
@@ -1,7 +1,9 @@
 ```{tags} Participant-Diversity, Presenter-Line-up, Embracing-Diverse-Voices-and-Experiences, Unconscious-and-Implicit-Bias, Tokenism
+
 ```
 
 (participant_and_speaker_selection)=
+
 # Participant and Speaker Selection
 
 ## Speakers
@@ -16,13 +18,14 @@
   - Research and follow speaker lists compiled by other organizations and communities
   - When querying your network for speaker ideas, specifically ask for suggestions of speakers who could contribute to the diversity of the speaker line-up
   - If your system is to have speakers come to you &amp; ask, but research shows they tend not to do so, they won&#39;t come.
-- 🍎 Consider the specific wording of how you solicit talks (subtlety can make a big difference) 
+- 🍎 Consider the specific wording of how you solicit talks (subtlety can make a big difference)
   - E.g. &quot;Experts in best practices&quot; may turn away people who don&#39;t self-identify as &quot;expert&quot; or who have impostor syndrome.
   - &quot;Speakers who have advice or expertise to share&quot; &gt; Everyone has some level of expertise or knowledge to share about what they work on, so this phrasing is more inclusive and inviting.
 - Ensure panels and roundtables include a diversity of participants
   - Make strategic use of the moderator role to help support diverse participation
 
 ### Selecting Speakers
+
 **Tags:** <span style="color:red"> Calls for Papers and Proposals</span>, <span style="color:red"> Presenter Line-up</span>, <span style="color:red"> Code of Conduct</span>
 
 - 🍎 Call For Proposals (CFP) instructions
@@ -68,23 +71,24 @@
 ### Call For Proposals review (&quot;double-blind&quot; vs &quot;affirmative action&quot;)
 
 **Tags:** <span style="color:red"> Unconscious and Implicit Bias</span>, <span style="color:red"> Discrimination</span>, <span style="color:red"> Calls for Papers & Proposals</span>, <span style="color:red"> Organisation and Program Committees</span>
-  - **&quot;Open&quot; versus &quot;Blind&quot; or &quot;Closed&quot; Review**
-    - &quot;Open&quot; review is a form of review in which the names of the reviewers are made public.
-    - &quot;Double-Open&quot; review is when the reviewers know the identity of the proposal author and the proposal author also knows the identity of their reviewers
-    - &quot;Double Blind&quot; review means the reviewers do not know the identity of the proposal author and vice versa. 
-    - &quot;Single Blind&quot; or simply &quot;Blind&quot; review means that the author of the proposal does not know the identity of the reviewers.
-    - Sometimes the term &quot;Closed&quot; or &quot;Anonymized&quot; is used instead of &quot;Blind&quot;.
-   - **Double &quot;Blind&quot; Review**
-     - By changing speaker selection to completely &quot;blind,&quot; you may be able to increase representation from traditionally underrepresented groups. (See &quot;Further Reading&quot; below.)
-      - You might create a CFP form that instructs the submitter to withhold identifying information.
-      - You can assign 1-2 people to remove the identifying information from submissions before passing them to the next group of reviewers/the assessing team.
-      - If you recognize a submission author and you&#39;re on the review committee, you should not grade the submission—recuse yourself from reviewing that submission.
-      - Optionally, the review team can de-anonymize after the review process to ensure that the final selection is representative of the diverse grouping that is desired.
-  - **Double Open Review**
-    - Reviewers know who the proposal authors are and proposal authors know who the reviewers are
-    - [Sample guidelines for reviewers in double open review systems](https://www.scipy2022.scipy.org/chair-reviewer-guidelines)
- - ✅ Regardless of which approach you choose, open or anonymized, we encourage you to make it &quot;double&quot; so that both parties know each other (double-open) or neither party knows the other (double-closed) 
- 
+
+- **&quot;Open&quot; versus &quot;Blind&quot; or &quot;Closed&quot; Review**
+  - &quot;Open&quot; review is a form of review in which the names of the reviewers are made public.
+  - &quot;Double-Open&quot; review is when the reviewers know the identity of the proposal author and the proposal author also knows the identity of their reviewers
+  - &quot;Double Blind&quot; review means the reviewers do not know the identity of the proposal author and vice versa.
+  - &quot;Single Blind&quot; or simply &quot;Blind&quot; review means that the author of the proposal does not know the identity of the reviewers.
+  - Sometimes the term &quot;Closed&quot; or &quot;Anonymized&quot; is used instead of &quot;Blind&quot;.
+- **Double &quot;Blind&quot; Review**
+  - By changing speaker selection to completely &quot;blind,&quot; you may be able to increase representation from traditionally underrepresented groups. (See &quot;Further Reading&quot; below.)
+  - You might create a CFP form that instructs the submitter to withhold identifying information.
+  - You can assign 1-2 people to remove the identifying information from submissions before passing them to the next group of reviewers/the assessing team.
+  - If you recognize a submission author and you&#39;re on the review committee, you should not grade the submission—recuse yourself from reviewing that submission.
+  - Optionally, the review team can de-anonymize after the review process to ensure that the final selection is representative of the diverse grouping that is desired.
+- **Double Open Review**
+  - Reviewers know who the proposal authors are and proposal authors know who the reviewers are
+  - [Sample guidelines for reviewers in double open review systems](https://www.scipy2022.scipy.org/chair-reviewer-guidelines)
+- ✅ Regardless of which approach you choose, open or anonymized, we encourage you to make it &quot;double&quot; so that both parties know each other (double-open) or neither party knows the other (double-closed)
+
 **Further reading:**
 
 - [Double- versus Single-Blind Review: New study provides evidence that when those reviewing panel submissions see a woman's name, she is less likely to be invited than if no name is seen](https://www.insidehighered.com/news/2016/09/07/new-study-suggests-continued-bias-academic-conference-panel-selections)
@@ -93,9 +97,72 @@
 - [Gender bias distorts peer review across fields](http://www.nature.com/news/gender-bias-distorts-peer-review-across-fields-1.21685)
 - [How rOpenSci uses Open Code Review to Promote Reproducible Science](https://www.numfocus.org/blog/how-ropensci-uses-code-review-to-promote-reproducible-science/)
 - [Conference Speaking and Diverse Perspectives with Carina C. Zona and Mark Yoon](https://www.techdoneright.io/9)
-Encourage double-blind reviewing processes.
+  Encourage double-blind reviewing processes.
 - [More on Improving Reviewing Quality with Double-Blind Reviewing, External Review Committees, Author Response, and in Person Program Committee Meetings](http://www.cs.utexas.edu/users/mckinley/notes/blind.html)
 - [Single versus Double blind reviewing at WSDM 2017](https://arxiv.org/abs/1702.00502)
 - [Effectiveness of Anonymization in Double-Blind Review] (https://arxiv.org/abs/1709.01609)
 
+## Conference Etiquette Guidelines
 
+To maintain a professional and respectful environment, here are important etiquette guidelines for conference participants:
+
+1. **Maintain Professional Conduct**
+
+   - Behave professionally during all conference activities
+   - Practice moderation at social events
+   - Remember you are representing yourself and your organization
+
+2. **Respect Speakers and Their Work**
+
+   - Engage constructively with speakers' content
+   - Ask questions that contribute to the discussion
+   - Save lengthy discussions or debates for after the session
+
+3. **Be Mindful During Q&A Sessions**
+
+   - Keep questions concise and relevant
+   - Allow others to have their turn at the microphone
+   - Save personal comments for post-session discussions
+
+4. **Show Respect for Others' Work**
+
+   - Provide constructive feedback when appropriate
+   - Avoid public criticism that could be considered hostile
+   - Remember that feedback should be professional and helpful
+
+5. **Practice Inclusive Behavior**
+
+   - Follow the Code of Conduct
+   - Treat all attendees with respect and courtesy
+   - Do not engage in harassment or discriminatory behavior
+
+6. **Take Care of Your Health**
+
+   - Remember to eat regular meals
+   - Stay hydrated
+   - Get adequate rest to maintain energy throughout the conference
+
+7. **Maintain Professional Relationships**
+
+   - Speak respectfully about colleagues and their work
+   - Focus on constructive discussion rather than criticism
+   - Build positive professional connections
+
+8. **Stay Open to Learning**
+
+   - Approach sessions with a learning mindset
+   - Value others' expertise and experience
+   - Be open to new perspectives and ideas
+
+9. **Be Considerate of Others' Time**
+
+   - Respect speakers' and attendees' time constraints
+   - Allow others to have their turn in discussions
+   - Be mindful of session schedules
+
+10. **Prioritize Health and Safety**
+    - Follow venue health guidelines
+    - Consider wearing masks when appropriate
+    - Stay home if you are feeling unwell
+
+These guidelines help create an environment where all participants can learn, network, and share ideas effectively while maintaining professional standards.


### PR DESCRIPTION
## Description##
This PR removes redundant text about secure data storage that appears in both the "Reporting" and "Enforcement" sections of the Code of Conduct. The information is more relevant to the Reporting section, so it has been removed from the Enforcement section to avoid duplication.

##Screenshots##
**Before
![Screenshot 2025-03-22 004039](https://github.com/user-attachments/assets/e59dd50f-57b2-47dc-bc2d-2317e70510f7)

**After
![Screenshot 2025-03-22 004115](https://github.com/user-attachments/assets/34096daa-40c7-4050-81d7-ed8ba427a122)


## Changes##
- Removed the following bullet point from the Enforcement section since it's already covered in the Reporting section:
   "When recording a CoC violation, ensure that the data are stored securely and that everyone's identities are protected. Access to the data should be limited."

## Location of Change##
Modified''7_code_of_conduct.md` to remove redundant text from the Enforcement section while keeping it in the Reporting section where it's more relevant.

## Related Issue##
Closes #240
Fixes #240 
