### PR TITLE
Replace 'Handbook' with 'Cookbook'  (#278)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,11 +1,11 @@
-## DISCOVER Handbook Governance Guide
+## DISCOVER Cookbook Governance Guide
 
 The purpose of this document is to outline the purpose, roles, and decision processes for this repository. The hope is to guide the community on how to accept contributions and maintain the cookbook to the standards of the NumFOCUS Community. 
 
 # **Open Source Project Objectives**
 
 * Conference Organizer Enablement
-  - Conference organizers should be able to easily access and use the handbook
+  - Conference organizers should be able to easily access and use the cookbook
   - Every effort will be made to be responsive to issues
 * Repo Quality
   - Repo remains in healthy state with good-quality, consistent codebase

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# DISCOVER-handbook
+# DISCOVER-cookbook
 ![All Contributors](https://img.shields.io/github/all-contributors/numfocus/DISCOVER-Cookbook?color=ee8449)
 
-The NumFOCUS DISCOVER Handbook (Diverse &amp; Inclusive Spaces and Conferences: Overall Vision and Essential Resources). A guide for organizing more diverse and inclusive events and conferences, produced by the NumFOCUS Diversity &amp; Inclusion in Scientific Computing (DISC) Program, with support from the Moore Foundation. 
+The NumFOCUS DISCOVER cookbook (Diverse &amp; Inclusive Spaces and Conferences: Overall Vision and Essential Resources). A guide for organizing more diverse and inclusive events and conferences, produced by the NumFOCUS Diversity &amp; Inclusion in Scientific Computing (DISC) Program, with support from the Moore Foundation. 
 
 If you are looking to read the book please visit https://discover-cookbook.numfocus.org/ for a live version of the book. This is the code that powers that website and is intended for maintainers and contributors.
 
@@ -81,7 +81,7 @@ conda env create -f environment.yml
 ```
 2. Activate the Conda Environment
 ```sh
-conda activate DISCOVER-handbook
+conda activate DISCOVER-cookbook
 ```
 3. Finally, to build the Jupyter Book
 ``` sh

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: DISCOVER-handbook
+name: DISCOVER-cookbook
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
This PR replaces all instances of "Handbook" with "Cookbook" in the all the file mentioned in the issue  to align with the project's preferred terminology.