### PR TITLE
Add contribution note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ While content is the heart of the project, the quality of the content needs to r
 
 For issues with other elements of the book, first make sure an issue is open and tracking can occur on the issue. Then open a a [pull request](https://github.com/numfocus/DISCOVER-Cookbook/pulls).
 
+> **Note:** To contribute effectively, check for active pull requests to avoid duplication, discuss your ideas in active issues or pull requests, and seek approval from maintainers or issue creators before proceeding. Respect others' contributions and collaborate constructively to improve the project.
 
 ### Contribution Workflow
 


### PR DESCRIPTION
This PR adds a note to the README file to help contributors avoid duplicate work. The note encourages checking for existing pull requests, discussing ideas in issues or PRs, and seeking approval before starting work.