### PR TITLE
Fixed preview.yml

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,26 +1,28 @@
-# .github/workflows/preview.yml
 name: Deploy PR previews
 
-on: workflow_dispatch
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
-#  pull_request:
-#    types:
-#      - opened
-#      - reopened
-#      - synchronize
-#      - closed
+permissions:
+  contents: write 
 
 concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.12.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.12.8
 
@@ -30,11 +32,15 @@ jobs:
         pip install sphinx-tags
 
     - name: Build the book
+      if: github.event.action != 'closed'
       run: |
         rm -rf DISCOVER/_tags/*
         jupyter-book build DISCOVER
 
     - name: Deploy PR Preview
-      uses: rossjrw/pr-preview-action@v1.2.0
+      uses: rossjrw/pr-preview-action@v1
       with:
         source-dir: ./DISCOVER/_build/html/
+        preview-branch: gh-pages
+        umbrella-dir: pr-preview
+        action: auto


### PR DESCRIPTION
This PR adds a GitHub Action that builds and deploys a preview of the book for each pull request.

The preview is automatically generated and hosted under gh-pages/pr-preview/ so changes can be reviewed live before merging.

Fixes #80.