### PR TITLE
Clarify Quiet Room Guidance for Sensory and Prayer Needs

### DIFF
--- a/DISCOVER/02_minimal_measures.md
+++ b/DISCOVER/02_minimal_measures.md
@@ -78,9 +78,11 @@ Conference chairs and lead organizers should take special care to recruit an org
 
 #### 🍎 Quiet Room
 
--   A dedicated room for people who need a break from the stimulation of being surrounded by people at the conference; no phone calls, talking/socializing, notification beeps! People whose religions require frequent prayer can make use of the quiet room.
+-   A dedicated room for people who need a break from the stimulation of being surrounded by people at the conference. It’s intended for quiet decompression — no phone calls, talking/socializing, notification beeps! 
 
--   Consider "quiet areas" if a separate room is not possible.
+- People whose religions require frequent prayer may also need a dedicated space. If possible, provide a separate, nearby room that allows for quiet personal prayer without disrupting others. If space is limited, work with the venue to offer a flexible-use room or provide access upon request.
+
+- If a separate room is not possible, consider "quiet areas" with soft seating, low lighting, and clear signage.
 
 ## [Catering](05_catering.md)
 


### PR DESCRIPTION
This PR updates the Quiet Room section in minimal_measures.md to:

Clearly define the Quiet Room as a silent, low-stimulation space intended for rest and sensory decompression.

Remove ambiguity around its use for prayer.

Add guidance for offering a separate room for attendees who need a space for quiet personal prayer.

Recommend practical fallbacks (e.g. flexible-use rooms or access upon request) where space is limited.

The update supports both accessibility and religious inclusion without compromising the intent of the Quiet Room.


Fixes #322