### PR TITLE
Added stale PR workflow 

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,38 @@
+name: Mark stale pull requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  
+  workflow_dispatch:      # Allow manual triggering
+
+permissions:
+  pull-requests: write
+  issues: read
+  contents: read
+
+jobs:
+  stale-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Disable for issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-message: 'This pull request has been inactive for 30 days. It will be closed in 14 days if no further activity occurs.'
+          close-pr-message: 'This pull request was closed due to inactivity for 44 days. Please feel free to reopen if you wish to continue working on this.'
+          stale-pr-label: '⌛ stale'
+          exempt-pr-labels: '🔄 changes required,✨ content enhancement,✍️ new content'
+          exempt-draft-pr: true
+          delete-branch: false
+          
+          only-pr-labels: ''  # Process all PRs
+          
+
+          operations-per-run: 30
+          enable-statistics: true
+
+          exempt-all-pr-milestones: true


### PR DESCRIPTION
## Description of Changes
Add GitHub Actions workflow to automatically manage inactive pull requests:
- Marks PRs as stale after 30 days of inactivity
- Closes stale PRs after 14 additional days without activity
- Exempts draft PRs and those with specific labels or milestones
- Configures proper permissions and runs daily

## Related Issue
#346 

## Type of Change

Please check the appropriate box that describes your PR:

- [ ] 🐛 Bug Fix — Fixes a documented issue or incorrect behavior
- [ ] ✨ Content Enhancement — Updates or improves existing content
- [ ] ✍️ New Content — Adds new chapters, examples, or significant sections
- [x] 🛠️ Other — Please describe in the *Description of Changes* section


## Additional Notes (Optional)

<!-- Add any other relevant context or information about the changes here.
     Include screenshots or references if helpful. -->


## Checklist

- [x] I have searched [open pull requests](https://github.com/numfocus/DISCOVER-Cookbook/pulls) to avoid duplicates.
- [x] I have built the book locally using the [build instructions](https://github.com/numfocus/DISCOVER-Cookbook#how-to-run-the-book-locally) and verified my changes work as expected.
- [x] I have written clear, conventional commit messages, as per the [Pull Request Guidelines](https://github.com/numfocus/DISCOVER-Cookbook/blob/main/CONTRIBUTING.md#pull-request-guidelines).
