### PR TITLE
Update repository and site URLs for 1.0 version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,12 +11,12 @@ permalink:           pretty
 title:               DISCOVER Cookbook
 tagline:             'Diverse & Inclusive Spaces and Conferences'
 description:         'The NumFOCUS DISCOVER Cookbook'
-url:                 https://discover-cookbook.github.io/
-giturl:              https://github.com/discover-cookbook/discover-cookbook.github.io
+url:                 https://discover-cookbook.numfocus.org/1.0/en
+giturl:              https://github.com/numfocus/DISCOVER-Cookbook
 baseurl:             / 
 paginate:            5
 
 # Custom vars
 version:             1.0
 
-github.repo: https://github.com/discover-cookbook/discover-cookbook.github.io
+github.repo: https://github.com/numfocus/DISCOVER-Cookbook


### PR DESCRIPTION
## **Description**

### **Changes Made**

**Update Repository URL for 1.0 version**
- Updated `giturl` from `https://github.com/discover-cookbook/discover-cookbook.github.io` to `https://github.com/numfocus/DISCOVER-Cookbook`
- Updated `github.repo` from `https://github.com/discover-cookbook/discover-cookbook.github.io` to `https://github.com/numfocus/DISCOVER-Cookbook`

The new site URL follows a versioned path structure (`/1.0/en`)

