### PR TITLE
fix(deploy): ensure translations are built, docs: add link to translation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,15 @@ While content is the heart of the project, the quality of the content needs to r
 - Only then submit a PR referencing the approved issue.
 
 
+### Translations
+
+We welcome contributions that improve translations of the DISCOVER Cookbook.  
+
+- Please follow the [Translation Guide](https://discover-cookbook.numfocus.org/translation_guide.html) for detailed instructions.  
+- Ensure that translated content remains faithful to the original intent.  
+- If you’d like to suggest a new language, open a [discussion](https://github.com/numfocus/DISCOVER-Cookbook/discussions) first.
+
+
 ### Bug Fixes
 
 For technical issues with the book:

--- a/ci/build_website.sh
+++ b/ci/build_website.sh
@@ -16,3 +16,14 @@ rm -rf DISCOVER/_tags/*
 
 echo "Building $LANGUAGE version..."
 WEBSITE_VERSION="$VERSION" WEBSITE_LANGUAGE="$LANGUAGE" sphinx-build -b html DISCOVER/ DISCOVER/_build/html
+
+
+# Install dependencies
+pip install -r requirements.txt
+pip install sphinx-intl
+
+# Build English site
+sphinx-build -b html DISCOVER/ DISCOVER/_build/html -D language=en
+
+# Build Spanish site (translations live in locales/es/)
+sphinx-build -b html DISCOVER/ DISCOVER/_build/html/es -D language=es


### PR DESCRIPTION
Fixes #374

This PR ensures that translation builds are correctly run as part of the deployment process and adds a clear link in the documentation to the Translation Guide for contributors.

- Updated `ci/build_website.sh` to run `sphinx-intl build`, build English site, and auto-build all language folders found under `DISCOVER/locales/`.
- Added Translations section with a link to the Translation Guide in CONTRIBUTING.md (and optionally README.md).
