### PR TITLE
fix translated builds

### DIFF
--- a/DISCOVER/conf.py
+++ b/DISCOVER/conf.py
@@ -36,6 +36,7 @@ author = 'Community'
 comments_config = {'hypothesis': False, 'utterances': False}
 copyright = '2023'
 exclude_patterns = ['**.ipynb_checkpoints', '.DS_Store', 'Thumbs.db', '_build']
+locale_dirs = ["../locales"]
 extensions = ['sphinx_togglebutton', 'sphinx_copybutton', 'myst_nb', 'jupyter_book', 'sphinx_external_toc', 'sphinx.ext.intersphinx', 'sphinx_design', 'sphinx_book_theme', 'sphinx_tags', 'sphinx_jupyterbook_latex', 'sphinx_multitoc_numbering']
 external_toc_exclude_missing = False
 external_toc_path = '_toc.yml'


### PR DESCRIPTION
## Description of Changes

Currently `/2.0/es` doesn't include the existing translations because sphinx isn't finding
any locales. This updates the locale_dirs in `conf.py` to point to the right place.

## Type of Change

Please check the appropriate box that describes your PR:

- [ ] 🐛 Bug Fix — Fixes a documented issue or incorrect behavior
- [ ] ✨ Content Enhancement — Updates or improves existing content
- [ ] ✍️ New Content — Adds new chapters, examples, or significant sections
- [x] 🛠️ Other — Please describe in the *Description of Changes* section


## Additional Notes (Optional)

<!-- Add any other relevant context or information about the changes here.
     Include screenshots or references if helpful. -->


## Checklist

- [x] I have searched [open pull requests](https://github.com/numfocus/DISCOVER-Cookbook/pulls) to avoid duplicates.
- [x] I have built the book locally using the [build instructions](https://github.com/numfocus/DISCOVER-Cookbook#how-to-run-the-book-locally) and verified my changes work as expected.
- [x] I have written clear, conventional commit messages, as per the [Pull Request Guidelines](https://github.com/numfocus/DISCOVER-Cookbook/blob/main/CONTRIBUTING.md#pull-request-guidelines).