### PR TITLE
[ Define ] : 'sponsor packet' term in Code of Conduct section - #239

### DIFF
--- a/DISCOVER/07_code_of_conduct.md
+++ b/DISCOVER/07_code_of_conduct.md
@@ -29,6 +29,7 @@ Make sure that **everyone involved in your conference/event** is aware that the 
      - A pop-up with a short version may also be a good idea.
      - Provide a link to the full ("less quick") version of the Code of Conduct, hosted on its own page.
  - 🍎 Include a copy of the Code of Conduct in the sponsor packet
+   - **Sponsor packet**: A collection of materials provided to event sponsors, typically including event guidelines, branding requirements, contact information, setup instructions, and key policies like the Code of Conduct. This packet is usually sent to sponsors before the event to ensure they understand their responsibilities and the event's standards.
  - 🍎 Mention that the Code of Conduct applies to the speakers in the speaker guidelines
  - 🍎 Ensure that the Code of Conduct is **easily** accessible on the conference website
    - Should be in main navigation or in the footer (footer is a known pattern, near privacy policy / terms of service)


### PR DESCRIPTION
Fixes #239

## 🎯 Problem
The term "sponsor packet" was mentioned in the Code of Conduct section without definition, causing confusion about:
- What a sponsor packet contains
- Who creates it
- Who receives it

## ✨ Solution
Added a clear definition directly below the mention of "sponsor packet":

> **Sponsor packet**: A collection of materials provided to event sponsors, typically including event guidelines, branding requirements, contact information, setup instructions, and key policies like the Code of Conduct. This packet is usually sent to sponsors before the event to ensure they understand their responsibilities and the event's standards.

## 📈 Benefits
- ✅ Eliminates confusion about sponsor packet terminology
- ✅ Provides actionable guidance for event organizers
- ✅ Clarifies sponsor communication process
- ✅ Improves overall documentation clarity

## 🧪 Testing
- Built documentation locally with `sphinx-build`
- Verified content renders correctly
- No build errors introduced
- Definition appears in proper context

## 📁 Files Changed
- [DISCOVER/07_code_of_conduct.md](cci:7://file:///Users/adarshpriydarshi/Desktop/DISCOVER-Cookbook/DISCOVER/07_code_of_conduct.md:0:0-0:0) - Added sponsor packet definition

---
This enhancement helps event organizers understand what materials to prepare for sponsors and ensures consistent communication about event standards.