### PR TITLE
Fix markdown formatting and typos in Translation.md

### DIFF
--- a/Translation.md
+++ b/Translation.md
@@ -54,7 +54,8 @@ We use Transifex to manage translations for the DISCOVER Cookbook. This guide ou
 
 ### Step 1: Installing the Transifex CLI
 
-Transifex provides a Go-based CLI for syncing translation files. Follow the (official installation instructions)[https://developers.transifex.com/docs/cli] for your operating system.
+
+Transifex provides a Go-based CLI for syncing translation files. Follow the [official installation instructions](https://developers.transifex.com/docs/cli) for your operating system.
 
 
 Verify installation:
@@ -63,7 +64,7 @@ tx --version
 ```
 Expected output:
 ```
-TX CLient, version=1.6.x
+TX Client, version=1.6.x
 ```
 
 ### Step 2: Authenticate with Transifex
@@ -112,4 +113,4 @@ tx pull -a -m reviewed
 
 ### Optional: Add Multiple Resources
 
-To add multiplt resorces, use [CLI](https://developers.transifex.com/docs/cli) setup.
+To add multiple resources, use [CLI](https://developers.transifex.com/docs/cli) setup.


### PR DESCRIPTION
Fixes multiple documentation errors in the translation workflow guide.

## Changes Made
- Fixed broken markdown link: `(text)[url]` → `[text](url)` on line 58
- Fixed typo: `multiplt` → `multiple` on line 116  
- Fixed typo: `CLient` → `Client` in CLI output example

## Impact
- Improved documentation readability
- Fixed broken link for Transifex CLI installation
- Enhanced professional appearance

## Testing
- Built locally with `sphinx-build`
- Verified links render correctly
- No build errors introduced

Files changed: [Translation.md](cci:7://file:///Users/adarshpriydarshi/Desktop/DISCOVER-Cookbook/Translation.md:0:0-0:0)