### PR TITLE
Fix: prevent section headings from being hidden behind sticky navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
         }
         .navbar { background-color: rgba(13, 17, 23, 0.85); }
         [data-bs-theme="light"] .navbar { background-color: rgba(255, 255, 255, 0.85); }
+
+          /* FIX: Add scroll padding to account for fixed navbar */
+        html {
+            scroll-behavior: smooth;
+            scroll-padding-top: 100px; /* Adjust based on navbar height + some spacing */
+        }
     </style>
 </head>
 <body>
@@ -30,8 +36,8 @@
         <div class="container">
             <!-- Main Logo -->
             <a class="navbar-brand fw-bold" href="#">
-                <img src="_static/images/logo-dark.png" alt="DISCOVER Cookbook" height="75" class="me-2 theme-logo dark-logo">
-                <img src="_static/images/logo-light.png" alt="DISCOVER Cookbook" height="75" class="me-2 theme-logo light-logo d-none">
+                <img src="/DISCOVER/_static/images/logo-dark.png" alt="DISCOVER Cookbook" height="75" class="me-2 theme-logo dark-logo">
+                <img src="/DISCOVER/_static/images/logo-light.png" alt="DISCOVER Cookbook" height="75" class="me-2 theme-logo light-logo d-none">
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"><span class="navbar-toggler-icon"></span></button>
             <div class="collapse navbar-collapse" id="navbarNav">


### PR DESCRIPTION
### Summary
Fixed an issue where clicking internal navbar anchors (About, Versions, Contribute)
caused the section titles to appear hidden behind the sticky navbar.

### Changes
- Added this into html <style> - scroll-behavior: smooth;
                                                     scroll-padding-top: 100px;
- Added scroll-padding or scroll-margin CSS to offset anchor jumps.
- Verified layout on both light and dark themes.

### How I tested
1. Ran `python -m http.server` locally.
2. Opened http://localhost:8000
3. Clicked all navigation links — headings now align correctly below the navbar.

### Screenshots
Before -  
<img width="1895" height="914" alt="Screenshot 2025-11-13 230010" src="https://github.com/user-attachments/assets/890e324f-e04e-496c-8e9a-cdfb4ba1fd62" />

After - 
<img width="1897" height="898" alt="Screenshot 2025-11-14 005207" src="https://github.com/user-attachments/assets/da57d7aa-0636-45ee-98a9-287cc305da5b" />

---
Fixes #426 
