### PR TITLE
Fix: NumFOCUS footer logo missing on Tag pages

### DIFF
--- a/DISCOVER/_static/js/footer.js
+++ b/DISCOVER/_static/js/footer.js
@@ -9,8 +9,8 @@ document.addEventListener('DOMContentLoaded', function() {
     footerContent.innerHTML = `
       <div class="footer-logo">
         <a href="https://numfocus.org" target="_blank" rel="noopener">
-          <img src="_static/images/Numfocus-logo-dark.png" alt="NumFOCUS" class="numfocus-logo light-mode-only">
-          <img src="_static/images/Numfocus-logo-light.png" alt="NumFOCUS" class="numfocus-logo dark-mode-only">
+          <img src="../_static/images/Numfocus-logo-dark.png" alt="NumFOCUS" class="numfocus-logo light-mode-only">
+          <img src="../_static/images/Numfocus-logo-light.png" alt="NumFOCUS" class="numfocus-logo dark-mode-only">
         </a>
       </div>
 


### PR DESCRIPTION
## Description of Changes

This pull request fixes a missing NumFOCUS logo in the footer across all tag-generated pages (_tags/*.html).
While the main pages display the correct NumFOCUS footer, the tag pages were missing the logo due to the footer script not being applied consistently to generated tag templates.

I updated the footer logic so that the NumFOCUS images correctly appear across all tag pages in both light and dark mode.
This improves consistency and branding across the site.


## Related Issue

Closes #432

## Type of Change

Please check the appropriate box that describes your PR:

- [x] 🐛 Bug Fix — Fixes a documented issue or incorrect behavior


## Additional Notes (Optional)

Verified locally that the footer now correctly displays:

NumFOCUS logo in light mode
NumFOCUS logo in dark mode


After fix

<img width="1919" height="992" alt="image" src="https://github.com/user-attachments/assets/39b6e6b5-3e72-4617-9af4-6bf3d9790548" />

## Checklist

- [x] I have searched [open pull requests](https://github.com/numfocus/DISCOVER-Cookbook/pulls) to avoid duplicates.
- [x] I have built the book locally using the [build instructions](https://github.com/numfocus/DISCOVER-Cookbook#how-to-run-the-book-locally) and verified my changes work as expected.
- [x] I have written clear, conventional commit messages, as per the [Pull Request Guidelines](https://github.com/numfocus/DISCOVER-Cookbook/blob/main/CONTRIBUTING.md#pull-request-guidelines).
